### PR TITLE
Explicit BetterEndForge and partial Environmental support

### DIFF
--- a/assets/betterendforge/blockstates/dragon_tree_leaves.json
+++ b/assets/betterendforge/blockstates/dragon_tree_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "betterendforge:block/dragon_tree_leaves1" },
-			{ "model": "betterendforge:block/dragon_tree_leaves2" },
-			{ "model": "betterendforge:block/dragon_tree_leaves3" },
-			{ "model": "betterendforge:block/dragon_tree_leaves4" },
-			{ "model": "betterendforge:block/dragon_tree_leaves5" },
-			{ "model": "betterendforge:block/dragon_tree_leaves6" },
-			{ "model": "betterendforge:block/dragon_tree_leaves7" },
-			{ "model": "betterendforge:block/dragon_tree_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "betterendforge:block/dragon_tree_leaves1" },
+      { "model": "betterendforge:block/dragon_tree_leaves2" },
+      { "model": "betterendforge:block/dragon_tree_leaves3" },
+      { "model": "betterendforge:block/dragon_tree_leaves4" },
+      { "model": "betterendforge:block/dragon_tree_leaves5" },
+      { "model": "betterendforge:block/dragon_tree_leaves6" },
+      { "model": "betterendforge:block/dragon_tree_leaves7" },
+      { "model": "betterendforge:block/dragon_tree_leaves8" }
+    ]
+  }
 }

--- a/assets/betterendforge/blockstates/dragon_tree_leaves.json
+++ b/assets/betterendforge/blockstates/dragon_tree_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "betterendforge:block/dragon_tree_leaves1" },
+			{ "model": "betterendforge:block/dragon_tree_leaves2" },
+			{ "model": "betterendforge:block/dragon_tree_leaves3" },
+			{ "model": "betterendforge:block/dragon_tree_leaves4" },
+			{ "model": "betterendforge:block/dragon_tree_leaves5" },
+			{ "model": "betterendforge:block/dragon_tree_leaves6" },
+			{ "model": "betterendforge:block/dragon_tree_leaves7" },
+			{ "model": "betterendforge:block/dragon_tree_leaves8" }
+		]
+    }
+}

--- a/assets/betterendforge/blockstates/lacugrove_leaves.json
+++ b/assets/betterendforge/blockstates/lacugrove_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "betterendforge:block/lacugrove_leaves1" },
-			{ "model": "betterendforge:block/lacugrove_leaves2" },
-			{ "model": "betterendforge:block/lacugrove_leaves3" },
-			{ "model": "betterendforge:block/lacugrove_leaves4" },
-			{ "model": "betterendforge:block/lacugrove_leaves5" },
-			{ "model": "betterendforge:block/lacugrove_leaves6" },
-			{ "model": "betterendforge:block/lacugrove_leaves7" },
-			{ "model": "betterendforge:block/lacugrove_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "betterendforge:block/lacugrove_leaves1" },
+      { "model": "betterendforge:block/lacugrove_leaves2" },
+      { "model": "betterendforge:block/lacugrove_leaves3" },
+      { "model": "betterendforge:block/lacugrove_leaves4" },
+      { "model": "betterendforge:block/lacugrove_leaves5" },
+      { "model": "betterendforge:block/lacugrove_leaves6" },
+      { "model": "betterendforge:block/lacugrove_leaves7" },
+      { "model": "betterendforge:block/lacugrove_leaves8" }
+    ]
+  }
 }

--- a/assets/betterendforge/blockstates/lacugrove_leaves.json
+++ b/assets/betterendforge/blockstates/lacugrove_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "betterendforge:block/lacugrove_leaves1" },
+			{ "model": "betterendforge:block/lacugrove_leaves2" },
+			{ "model": "betterendforge:block/lacugrove_leaves3" },
+			{ "model": "betterendforge:block/lacugrove_leaves4" },
+			{ "model": "betterendforge:block/lacugrove_leaves5" },
+			{ "model": "betterendforge:block/lacugrove_leaves6" },
+			{ "model": "betterendforge:block/lacugrove_leaves7" },
+			{ "model": "betterendforge:block/lacugrove_leaves8" }
+		]
+    }
+}

--- a/assets/betterendforge/blockstates/pythadendron_leaves.json
+++ b/assets/betterendforge/blockstates/pythadendron_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "betterendforge:block/pythadendron_leaves1" },
+			{ "model": "betterendforge:block/pythadendron_leaves2" },
+			{ "model": "betterendforge:block/pythadendron_leaves3" },
+			{ "model": "betterendforge:block/pythadendron_leaves4" },
+			{ "model": "betterendforge:block/pythadendron_leaves5" },
+			{ "model": "betterendforge:block/pythadendron_leaves6" },
+			{ "model": "betterendforge:block/pythadendron_leaves7" },
+			{ "model": "betterendforge:block/pythadendron_leaves8" }
+		]
+    }
+}

--- a/assets/betterendforge/blockstates/pythadendron_leaves.json
+++ b/assets/betterendforge/blockstates/pythadendron_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "betterendforge:block/pythadendron_leaves1" },
-			{ "model": "betterendforge:block/pythadendron_leaves2" },
-			{ "model": "betterendforge:block/pythadendron_leaves3" },
-			{ "model": "betterendforge:block/pythadendron_leaves4" },
-			{ "model": "betterendforge:block/pythadendron_leaves5" },
-			{ "model": "betterendforge:block/pythadendron_leaves6" },
-			{ "model": "betterendforge:block/pythadendron_leaves7" },
-			{ "model": "betterendforge:block/pythadendron_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "betterendforge:block/pythadendron_leaves1" },
+      { "model": "betterendforge:block/pythadendron_leaves2" },
+      { "model": "betterendforge:block/pythadendron_leaves3" },
+      { "model": "betterendforge:block/pythadendron_leaves4" },
+      { "model": "betterendforge:block/pythadendron_leaves5" },
+      { "model": "betterendforge:block/pythadendron_leaves6" },
+      { "model": "betterendforge:block/pythadendron_leaves7" },
+      { "model": "betterendforge:block/pythadendron_leaves8" }
+    ]
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves1.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves1.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves2.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves2.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves3.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves3.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves4.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves4.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves5.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves5.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves6.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves6.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves7.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/dragon_tree_leaves7.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves8.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"betterendforge:block/dragon_tree_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/dragon_tree_leaves8.json
+++ b/assets/betterendforge/models/block/dragon_tree_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"betterendforge:block/dragon_tree_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "betterendforge:block/dragon_tree_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves1.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves1.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves2.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves2.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves3.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves3.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves4.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves4.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves5.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves5.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves6.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves6.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves7.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves7.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/lacugrove_leaves8.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"betterendforge:block/lacugrove_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/lacugrove_leaves8.json
+++ b/assets/betterendforge/models/block/lacugrove_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"betterendforge:block/lacugrove_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "betterendforge:block/lacugrove_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves1.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves1.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves2.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves2.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves3.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves3.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves4.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves4.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves5.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves5.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves6.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves6.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves7.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/betterendforge/models/block/pythadendron_leaves7.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves8.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"betterendforge:block/pythadendron_leaves"
+    }
+}

--- a/assets/betterendforge/models/block/pythadendron_leaves8.json
+++ b/assets/betterendforge/models/block/pythadendron_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"betterendforge:block/pythadendron_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "betterendforge:block/pythadendron_leaves"
+  }
 }

--- a/assets/environmental/blockstates/blue_wisteria_leaves.json
+++ b/assets/environmental/blockstates/blue_wisteria_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "environmental:block/blue_wisteria_leaves1" },
-			{ "model": "environmental:block/blue_wisteria_leaves2" },
-			{ "model": "environmental:block/blue_wisteria_leaves3" },
-			{ "model": "environmental:block/blue_wisteria_leaves4" },
-			{ "model": "environmental:block/blue_wisteria_leaves5" },
-			{ "model": "environmental:block/blue_wisteria_leaves6" },
-			{ "model": "environmental:block/blue_wisteria_leaves7" },
-			{ "model": "environmental:block/blue_wisteria_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "environmental:block/blue_wisteria_leaves1" },
+      { "model": "environmental:block/blue_wisteria_leaves2" },
+      { "model": "environmental:block/blue_wisteria_leaves3" },
+      { "model": "environmental:block/blue_wisteria_leaves4" },
+      { "model": "environmental:block/blue_wisteria_leaves5" },
+      { "model": "environmental:block/blue_wisteria_leaves6" },
+      { "model": "environmental:block/blue_wisteria_leaves7" },
+      { "model": "environmental:block/blue_wisteria_leaves8" }
+    ]
+  }
 }

--- a/assets/environmental/blockstates/blue_wisteria_leaves.json
+++ b/assets/environmental/blockstates/blue_wisteria_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "environmental:block/blue_wisteria_leaves1" },
+			{ "model": "environmental:block/blue_wisteria_leaves2" },
+			{ "model": "environmental:block/blue_wisteria_leaves3" },
+			{ "model": "environmental:block/blue_wisteria_leaves4" },
+			{ "model": "environmental:block/blue_wisteria_leaves5" },
+			{ "model": "environmental:block/blue_wisteria_leaves6" },
+			{ "model": "environmental:block/blue_wisteria_leaves7" },
+			{ "model": "environmental:block/blue_wisteria_leaves8" }
+		]
+    }
+}

--- a/assets/environmental/blockstates/pink_wisteria_leaves.json
+++ b/assets/environmental/blockstates/pink_wisteria_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "environmental:block/pink_wisteria_leaves1" },
-			{ "model": "environmental:block/pink_wisteria_leaves2" },
-			{ "model": "environmental:block/pink_wisteria_leaves3" },
-			{ "model": "environmental:block/pink_wisteria_leaves4" },
-			{ "model": "environmental:block/pink_wisteria_leaves5" },
-			{ "model": "environmental:block/pink_wisteria_leaves6" },
-			{ "model": "environmental:block/pink_wisteria_leaves7" },
-			{ "model": "environmental:block/pink_wisteria_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "environmental:block/pink_wisteria_leaves1" },
+      { "model": "environmental:block/pink_wisteria_leaves2" },
+      { "model": "environmental:block/pink_wisteria_leaves3" },
+      { "model": "environmental:block/pink_wisteria_leaves4" },
+      { "model": "environmental:block/pink_wisteria_leaves5" },
+      { "model": "environmental:block/pink_wisteria_leaves6" },
+      { "model": "environmental:block/pink_wisteria_leaves7" },
+      { "model": "environmental:block/pink_wisteria_leaves8" }
+    ]
+  }
 }

--- a/assets/environmental/blockstates/pink_wisteria_leaves.json
+++ b/assets/environmental/blockstates/pink_wisteria_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "environmental:block/pink_wisteria_leaves1" },
+			{ "model": "environmental:block/pink_wisteria_leaves2" },
+			{ "model": "environmental:block/pink_wisteria_leaves3" },
+			{ "model": "environmental:block/pink_wisteria_leaves4" },
+			{ "model": "environmental:block/pink_wisteria_leaves5" },
+			{ "model": "environmental:block/pink_wisteria_leaves6" },
+			{ "model": "environmental:block/pink_wisteria_leaves7" },
+			{ "model": "environmental:block/pink_wisteria_leaves8" }
+		]
+    }
+}

--- a/assets/environmental/blockstates/purple_wisteria_leaves.json
+++ b/assets/environmental/blockstates/purple_wisteria_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "environmental:block/purple_wisteria_leaves1" },
-			{ "model": "environmental:block/purple_wisteria_leaves2" },
-			{ "model": "environmental:block/purple_wisteria_leaves3" },
-			{ "model": "environmental:block/purple_wisteria_leaves4" },
-			{ "model": "environmental:block/purple_wisteria_leaves5" },
-			{ "model": "environmental:block/purple_wisteria_leaves6" },
-			{ "model": "environmental:block/purple_wisteria_leaves7" },
-			{ "model": "environmental:block/purple_wisteria_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "environmental:block/purple_wisteria_leaves1" },
+      { "model": "environmental:block/purple_wisteria_leaves2" },
+      { "model": "environmental:block/purple_wisteria_leaves3" },
+      { "model": "environmental:block/purple_wisteria_leaves4" },
+      { "model": "environmental:block/purple_wisteria_leaves5" },
+      { "model": "environmental:block/purple_wisteria_leaves6" },
+      { "model": "environmental:block/purple_wisteria_leaves7" },
+      { "model": "environmental:block/purple_wisteria_leaves8" }
+    ]
+  }
 }

--- a/assets/environmental/blockstates/purple_wisteria_leaves.json
+++ b/assets/environmental/blockstates/purple_wisteria_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "environmental:block/purple_wisteria_leaves1" },
+			{ "model": "environmental:block/purple_wisteria_leaves2" },
+			{ "model": "environmental:block/purple_wisteria_leaves3" },
+			{ "model": "environmental:block/purple_wisteria_leaves4" },
+			{ "model": "environmental:block/purple_wisteria_leaves5" },
+			{ "model": "environmental:block/purple_wisteria_leaves6" },
+			{ "model": "environmental:block/purple_wisteria_leaves7" },
+			{ "model": "environmental:block/purple_wisteria_leaves8" }
+		]
+    }
+}

--- a/assets/environmental/blockstates/white_wisteria_leaves.json
+++ b/assets/environmental/blockstates/white_wisteria_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "environmental:block/white_wisteria_leaves1" },
+			{ "model": "environmental:block/white_wisteria_leaves2" },
+			{ "model": "environmental:block/white_wisteria_leaves3" },
+			{ "model": "environmental:block/white_wisteria_leaves4" },
+			{ "model": "environmental:block/white_wisteria_leaves5" },
+			{ "model": "environmental:block/white_wisteria_leaves6" },
+			{ "model": "environmental:block/white_wisteria_leaves7" },
+			{ "model": "environmental:block/white_wisteria_leaves8" }
+		]
+    }
+}

--- a/assets/environmental/blockstates/white_wisteria_leaves.json
+++ b/assets/environmental/blockstates/white_wisteria_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "environmental:block/white_wisteria_leaves1" },
-			{ "model": "environmental:block/white_wisteria_leaves2" },
-			{ "model": "environmental:block/white_wisteria_leaves3" },
-			{ "model": "environmental:block/white_wisteria_leaves4" },
-			{ "model": "environmental:block/white_wisteria_leaves5" },
-			{ "model": "environmental:block/white_wisteria_leaves6" },
-			{ "model": "environmental:block/white_wisteria_leaves7" },
-			{ "model": "environmental:block/white_wisteria_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "environmental:block/white_wisteria_leaves1" },
+      { "model": "environmental:block/white_wisteria_leaves2" },
+      { "model": "environmental:block/white_wisteria_leaves3" },
+      { "model": "environmental:block/white_wisteria_leaves4" },
+      { "model": "environmental:block/white_wisteria_leaves5" },
+      { "model": "environmental:block/white_wisteria_leaves6" },
+      { "model": "environmental:block/white_wisteria_leaves7" },
+      { "model": "environmental:block/white_wisteria_leaves8" }
+    ]
+  }
 }

--- a/assets/environmental/blockstates/willow_leaves.json
+++ b/assets/environmental/blockstates/willow_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "environmental:block/willow_leaves1" },
+			{ "model": "environmental:block/willow_leaves2" },
+			{ "model": "environmental:block/willow_leaves3" },
+			{ "model": "environmental:block/willow_leaves4" },
+			{ "model": "environmental:block/willow_leaves5" },
+			{ "model": "environmental:block/willow_leaves6" },
+			{ "model": "environmental:block/willow_leaves7" },
+			{ "model": "environmental:block/willow_leaves8" }
+		]
+    }
+}

--- a/assets/environmental/blockstates/willow_leaves.json
+++ b/assets/environmental/blockstates/willow_leaves.json
@@ -1,14 +1,14 @@
 {
-    "variants": {
-        "": [
-			{ "model": "environmental:block/willow_leaves1" },
-			{ "model": "environmental:block/willow_leaves2" },
-			{ "model": "environmental:block/willow_leaves3" },
-			{ "model": "environmental:block/willow_leaves4" },
-			{ "model": "environmental:block/willow_leaves5" },
-			{ "model": "environmental:block/willow_leaves6" },
-			{ "model": "environmental:block/willow_leaves7" },
-			{ "model": "environmental:block/willow_leaves8" }
-		]
-    }
+  "variants": {
+    "": [
+      { "model": "environmental:block/willow_leaves1" },
+      { "model": "environmental:block/willow_leaves2" },
+      { "model": "environmental:block/willow_leaves3" },
+      { "model": "environmental:block/willow_leaves4" },
+      { "model": "environmental:block/willow_leaves5" },
+      { "model": "environmental:block/willow_leaves6" },
+      { "model": "environmental:block/willow_leaves7" },
+      { "model": "environmental:block/willow_leaves8" }
+    ]
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves1.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves1.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves2.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves2.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves3.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves3.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves4.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves4.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves5.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves5.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves6.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves6.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves7.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves7.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/blue_wisteria_leaves8.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"environmental:block/blue_wisteria_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "environmental:block/blue_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/blue_wisteria_leaves8.json
+++ b/assets/environmental/models/block/blue_wisteria_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"environmental:block/blue_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves1.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves1.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves2.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves2.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves3.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves3.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves4.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves4.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves5.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves5.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves6.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves6.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves7.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves7.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/pink_wisteria_leaves8.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"environmental:block/pink_wisteria_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "environmental:block/pink_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/pink_wisteria_leaves8.json
+++ b/assets/environmental/models/block/pink_wisteria_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"environmental:block/pink_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves1.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves1.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves2.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves2.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves3.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves3.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves4.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves4.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves5.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves5.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves6.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves6.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves7.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/purple_wisteria_leaves7.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves8.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"environmental:block/purple_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/purple_wisteria_leaves8.json
+++ b/assets/environmental/models/block/purple_wisteria_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"environmental:block/purple_wisteria_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "environmental:block/purple_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves1.json
+++ b/assets/environmental/models/block/white_wisteria_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves1.json
+++ b/assets/environmental/models/block/white_wisteria_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves2.json
+++ b/assets/environmental/models/block/white_wisteria_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves2.json
+++ b/assets/environmental/models/block/white_wisteria_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves3.json
+++ b/assets/environmental/models/block/white_wisteria_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves3.json
+++ b/assets/environmental/models/block/white_wisteria_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves4.json
+++ b/assets/environmental/models/block/white_wisteria_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves4.json
+++ b/assets/environmental/models/block/white_wisteria_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves5.json
+++ b/assets/environmental/models/block/white_wisteria_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves5.json
+++ b/assets/environmental/models/block/white_wisteria_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves6.json
+++ b/assets/environmental/models/block/white_wisteria_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves6.json
+++ b/assets/environmental/models/block/white_wisteria_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves7.json
+++ b/assets/environmental/models/block/white_wisteria_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves7.json
+++ b/assets/environmental/models/block/white_wisteria_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/white_wisteria_leaves8.json
+++ b/assets/environmental/models/block/white_wisteria_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"environmental:block/white_wisteria_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "environmental:block/white_wisteria_leaves"
+  }
 }

--- a/assets/environmental/models/block/white_wisteria_leaves8.json
+++ b/assets/environmental/models/block/white_wisteria_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"environmental:block/white_wisteria_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves1.json
+++ b/assets/environmental/models/block/willow_leaves1.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves1",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves1",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves1.json
+++ b/assets/environmental/models/block/willow_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves2.json
+++ b/assets/environmental/models/block/willow_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves2.json
+++ b/assets/environmental/models/block/willow_leaves2.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves2",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves2",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves3.json
+++ b/assets/environmental/models/block/willow_leaves3.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves3",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves3",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves3.json
+++ b/assets/environmental/models/block/willow_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves4.json
+++ b/assets/environmental/models/block/willow_leaves4.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves4",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves4",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves4.json
+++ b/assets/environmental/models/block/willow_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves5.json
+++ b/assets/environmental/models/block/willow_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves5.json
+++ b/assets/environmental/models/block/willow_leaves5.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves5",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves5",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves6.json
+++ b/assets/environmental/models/block/willow_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves6.json
+++ b/assets/environmental/models/block/willow_leaves6.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves6",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves6",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves7.json
+++ b/assets/environmental/models/block/willow_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves7.json
+++ b/assets/environmental/models/block/willow_leaves7.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves7",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves7",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }

--- a/assets/environmental/models/block/willow_leaves8.json
+++ b/assets/environmental/models/block/willow_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"environmental:block/willow_leaves"
+    }
+}

--- a/assets/environmental/models/block/willow_leaves8.json
+++ b/assets/environmental/models/block/willow_leaves8.json
@@ -1,6 +1,6 @@
 {
-    "parent":"block/leaves8",
-    "textures": {
-        "0":"environmental:block/willow_leaves"
-    }
+  "parent": "block/leaves8",
+  "textures": {
+    "0": "environmental:block/willow_leaves"
+  }
 }


### PR DESCRIPTION
Sorry I never got around to making the Fabric PR on Round Trees, but I decided to use good ol' find and replace to copy BetterEnd into BetterEndForge and merge Bloomful and Swamp Expansion into Environmental. 
I think it might be an idea to delete the Bloomful and Swamp Expansion folders, since those mods are now defunct.
I don't know how to properly add mod support here, so Environmental's new cherry trees aren't supported.