### PR TITLE
Ars Nouveau Support and Mod Updates

### DIFF
--- a/assets/aether/blockstates/crystal_fruit_leaves.json
+++ b/assets/aether/blockstates/crystal_fruit_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "aether:block/crystal_fruit_leaves1" },
+			{ "model": "aether:block/crystal_fruit_leaves2" },
+			{ "model": "aether:block/crystal_fruit_leaves3" },
+			{ "model": "aether:block/crystal_fruit_leaves4" },
+			{ "model": "aether:block/crystal_fruit_leaves5" },
+			{ "model": "aether:block/crystal_fruit_leaves6" },
+			{ "model": "aether:block/crystal_fruit_leaves7" },
+			{ "model": "aether:block/crystal_fruit_leaves8" }
+		]
+    }
+}

--- a/assets/aether/blockstates/crystal_leaves.json
+++ b/assets/aether/blockstates/crystal_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "aether:block/crystal_leaves1" },
+			{ "model": "aether:block/crystal_leaves2" },
+			{ "model": "aether:block/crystal_leaves3" },
+			{ "model": "aether:block/crystal_leaves4" },
+			{ "model": "aether:block/crystal_leaves5" },
+			{ "model": "aether:block/crystal_leaves6" },
+			{ "model": "aether:block/crystal_leaves7" },
+			{ "model": "aether:block/crystal_leaves8" }
+		]
+    }
+}

--- a/assets/aether/blockstates/decorated_holiday_leaves.json
+++ b/assets/aether/blockstates/decorated_holiday_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "aether:block/decorated_holiday_leaves1" },
+			{ "model": "aether:block/decorated_holiday_leaves2" },
+			{ "model": "aether:block/decorated_holiday_leaves3" },
+			{ "model": "aether:block/decorated_holiday_leaves4" },
+			{ "model": "aether:block/decorated_holiday_leaves5" },
+			{ "model": "aether:block/decorated_holiday_leaves6" },
+			{ "model": "aether:block/decorated_holiday_leaves7" },
+			{ "model": "aether:block/decorated_holiday_leaves8" }
+		]
+    }
+}

--- a/assets/aether/blockstates/golden_oak_leaves.json
+++ b/assets/aether/blockstates/golden_oak_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "aether:block/golden_oak_leaves1" },
+			{ "model": "aether:block/golden_oak_leaves2" },
+			{ "model": "aether:block/golden_oak_leaves3" },
+			{ "model": "aether:block/golden_oak_leaves4" },
+			{ "model": "aether:block/golden_oak_leaves5" },
+			{ "model": "aether:block/golden_oak_leaves6" },
+			{ "model": "aether:block/golden_oak_leaves7" },
+			{ "model": "aether:block/golden_oak_leaves8" }
+		]
+    }
+}

--- a/assets/aether/blockstates/holiday_leaves.json
+++ b/assets/aether/blockstates/holiday_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "aether:block/holiday_leaves1" },
+			{ "model": "aether:block/holiday_leaves2" },
+			{ "model": "aether:block/holiday_leaves3" },
+			{ "model": "aether:block/holiday_leaves4" },
+			{ "model": "aether:block/holiday_leaves5" },
+			{ "model": "aether:block/holiday_leaves6" },
+			{ "model": "aether:block/holiday_leaves7" },
+			{ "model": "aether:block/holiday_leaves8" }
+		]
+    }
+}

--- a/assets/aether/blockstates/skyroot_leaves.json
+++ b/assets/aether/blockstates/skyroot_leaves.json
@@ -1,0 +1,14 @@
+{
+    "variants": {
+        "": [
+			{ "model": "aether:block/skyroot_leaves1" },
+			{ "model": "aether:block/skyroot_leaves2" },
+			{ "model": "aether:block/skyroot_leaves3" },
+			{ "model": "aether:block/skyroot_leaves4" },
+			{ "model": "aether:block/skyroot_leaves5" },
+			{ "model": "aether:block/skyroot_leaves6" },
+			{ "model": "aether:block/skyroot_leaves7" },
+			{ "model": "aether:block/skyroot_leaves8" }
+		]
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves1.json
+++ b/assets/aether/models/block/crystal_fruit_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves2.json
+++ b/assets/aether/models/block/crystal_fruit_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves3.json
+++ b/assets/aether/models/block/crystal_fruit_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves4.json
+++ b/assets/aether/models/block/crystal_fruit_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves5.json
+++ b/assets/aether/models/block/crystal_fruit_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves6.json
+++ b/assets/aether/models/block/crystal_fruit_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves7.json
+++ b/assets/aether/models/block/crystal_fruit_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_fruit_leaves8.json
+++ b/assets/aether/models/block/crystal_fruit_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"aether:block/natural/crystal_fruit_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves1.json
+++ b/assets/aether/models/block/crystal_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves2.json
+++ b/assets/aether/models/block/crystal_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves3.json
+++ b/assets/aether/models/block/crystal_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves4.json
+++ b/assets/aether/models/block/crystal_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves5.json
+++ b/assets/aether/models/block/crystal_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves6.json
+++ b/assets/aether/models/block/crystal_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves7.json
+++ b/assets/aether/models/block/crystal_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/crystal_leaves8.json
+++ b/assets/aether/models/block/crystal_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"aether:block/natural/crystal_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves1.json
+++ b/assets/aether/models/block/decorated_holiday_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves2.json
+++ b/assets/aether/models/block/decorated_holiday_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves3.json
+++ b/assets/aether/models/block/decorated_holiday_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves4.json
+++ b/assets/aether/models/block/decorated_holiday_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves5.json
+++ b/assets/aether/models/block/decorated_holiday_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves6.json
+++ b/assets/aether/models/block/decorated_holiday_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves7.json
+++ b/assets/aether/models/block/decorated_holiday_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/decorated_holiday_leaves8.json
+++ b/assets/aether/models/block/decorated_holiday_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"aether:block/natural/decorated_holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves1.json
+++ b/assets/aether/models/block/golden_oak_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves2.json
+++ b/assets/aether/models/block/golden_oak_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves3.json
+++ b/assets/aether/models/block/golden_oak_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves4.json
+++ b/assets/aether/models/block/golden_oak_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves5.json
+++ b/assets/aether/models/block/golden_oak_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves6.json
+++ b/assets/aether/models/block/golden_oak_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves7.json
+++ b/assets/aether/models/block/golden_oak_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/golden_oak_leaves8.json
+++ b/assets/aether/models/block/golden_oak_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"aether:block/natural/golden_oak_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves1.json
+++ b/assets/aether/models/block/holiday_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves2.json
+++ b/assets/aether/models/block/holiday_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves3.json
+++ b/assets/aether/models/block/holiday_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves4.json
+++ b/assets/aether/models/block/holiday_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves5.json
+++ b/assets/aether/models/block/holiday_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves6.json
+++ b/assets/aether/models/block/holiday_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves7.json
+++ b/assets/aether/models/block/holiday_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/holiday_leaves8.json
+++ b/assets/aether/models/block/holiday_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"aether:block/natural/holiday_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves1.json
+++ b/assets/aether/models/block/skyroot_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves2.json
+++ b/assets/aether/models/block/skyroot_leaves2.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves2",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves3.json
+++ b/assets/aether/models/block/skyroot_leaves3.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves3",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves4.json
+++ b/assets/aether/models/block/skyroot_leaves4.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves4",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves5.json
+++ b/assets/aether/models/block/skyroot_leaves5.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves5",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves6.json
+++ b/assets/aether/models/block/skyroot_leaves6.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves6",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves7.json
+++ b/assets/aether/models/block/skyroot_leaves7.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves7",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/aether/models/block/skyroot_leaves8.json
+++ b/assets/aether/models/block/skyroot_leaves8.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves8",
+    "textures": {
+        "0":"aether:block/natural/skyroot_leaves"
+    }
+}

--- a/assets/ars_nouveau/blockstates/blue_archwood_leaves.json
+++ b/assets/ars_nouveau/blockstates/blue_archwood_leaves.json
@@ -1,0 +1,10 @@
+{  "variants": {    "": [
+      { "model": "ars_nouveau:block/blue_archwood_leaves1" }, { "model": "ars_nouveau:block/blue_archwood_leaves1", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves1", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves1", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves2" }, { "model": "ars_nouveau:block/blue_archwood_leaves2", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves2", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves2", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves3" }, { "model": "ars_nouveau:block/blue_archwood_leaves3", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves3", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves3", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves4" }, { "model": "ars_nouveau:block/blue_archwood_leaves4", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves4", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves4", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves5" }, { "model": "ars_nouveau:block/blue_archwood_leaves5", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves5", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves5", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves6" }, { "model": "ars_nouveau:block/blue_archwood_leaves6", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves6", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves6", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves7" }, { "model": "ars_nouveau:block/blue_archwood_leaves7", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves7", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves7", "y": 270 },
+      { "model": "ars_nouveau:block/blue_archwood_leaves8" }, { "model": "ars_nouveau:block/blue_archwood_leaves8", "y": 90 }, { "model": "ars_nouveau:block/blue_archwood_leaves8", "y": 180 }, { "model": "ars_nouveau:block/blue_archwood_leaves8", "y": 270 }
+]}}

--- a/assets/ars_nouveau/blockstates/green_archwood_leaves.json
+++ b/assets/ars_nouveau/blockstates/green_archwood_leaves.json
@@ -1,0 +1,10 @@
+{  "variants": {    "": [
+      { "model": "ars_nouveau:block/green_archwood_leaves1" }, { "model": "ars_nouveau:block/green_archwood_leaves1", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves1", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves1", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves2" }, { "model": "ars_nouveau:block/green_archwood_leaves2", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves2", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves2", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves3" }, { "model": "ars_nouveau:block/green_archwood_leaves3", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves3", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves3", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves4" }, { "model": "ars_nouveau:block/green_archwood_leaves4", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves4", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves4", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves5" }, { "model": "ars_nouveau:block/green_archwood_leaves5", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves5", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves5", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves6" }, { "model": "ars_nouveau:block/green_archwood_leaves6", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves6", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves6", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves7" }, { "model": "ars_nouveau:block/green_archwood_leaves7", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves7", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves7", "y": 270 },
+      { "model": "ars_nouveau:block/green_archwood_leaves8" }, { "model": "ars_nouveau:block/green_archwood_leaves8", "y": 90 }, { "model": "ars_nouveau:block/green_archwood_leaves8", "y": 180 }, { "model": "ars_nouveau:block/green_archwood_leaves8", "y": 270 }
+]}}

--- a/assets/ars_nouveau/blockstates/purple_archwood_leaves.json
+++ b/assets/ars_nouveau/blockstates/purple_archwood_leaves.json
@@ -1,0 +1,10 @@
+{  "variants": {    "": [
+      { "model": "ars_nouveau:block/purple_archwood_leaves1" }, { "model": "ars_nouveau:block/purple_archwood_leaves1", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves1", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves1", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves2" }, { "model": "ars_nouveau:block/purple_archwood_leaves2", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves2", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves2", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves3" }, { "model": "ars_nouveau:block/purple_archwood_leaves3", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves3", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves3", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves4" }, { "model": "ars_nouveau:block/purple_archwood_leaves4", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves4", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves4", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves5" }, { "model": "ars_nouveau:block/purple_archwood_leaves5", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves5", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves5", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves6" }, { "model": "ars_nouveau:block/purple_archwood_leaves6", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves6", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves6", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves7" }, { "model": "ars_nouveau:block/purple_archwood_leaves7", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves7", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves7", "y": 270 },
+      { "model": "ars_nouveau:block/purple_archwood_leaves8" }, { "model": "ars_nouveau:block/purple_archwood_leaves8", "y": 90 }, { "model": "ars_nouveau:block/purple_archwood_leaves8", "y": 180 }, { "model": "ars_nouveau:block/purple_archwood_leaves8", "y": 270 }
+]}}

--- a/assets/ars_nouveau/blockstates/red_archwood_leaves.json
+++ b/assets/ars_nouveau/blockstates/red_archwood_leaves.json
@@ -1,0 +1,10 @@
+{  "variants": {    "": [
+      { "model": "ars_nouveau:block/red_archwood_leaves1" }, { "model": "ars_nouveau:block/red_archwood_leaves1", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves1", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves1", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves2" }, { "model": "ars_nouveau:block/red_archwood_leaves2", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves2", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves2", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves3" }, { "model": "ars_nouveau:block/red_archwood_leaves3", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves3", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves3", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves4" }, { "model": "ars_nouveau:block/red_archwood_leaves4", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves4", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves4", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves5" }, { "model": "ars_nouveau:block/red_archwood_leaves5", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves5", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves5", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves6" }, { "model": "ars_nouveau:block/red_archwood_leaves6", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves6", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves6", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves7" }, { "model": "ars_nouveau:block/red_archwood_leaves7", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves7", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves7", "y": 270 },
+      { "model": "ars_nouveau:block/red_archwood_leaves8" }, { "model": "ars_nouveau:block/red_archwood_leaves8", "y": 90 }, { "model": "ars_nouveau:block/red_archwood_leaves8", "y": 180 }, { "model": "ars_nouveau:block/red_archwood_leaves8", "y": 270 }
+]}}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves1.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves1.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves1",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves2.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves2.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves2",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves3.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves3.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves3",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves4.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves4.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves4",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves5.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves5.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves5",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves6.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves6.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves6",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves7.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves7.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves7",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/blue_archwood_leaves8.json
+++ b/assets/ars_nouveau/models/block/blue_archwood_leaves8.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves8",  "textures": {    "0":"ars_nouveau:block/blue_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves1.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves1.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves1",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves2.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves2.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves2",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves3.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves3.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves3",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves4.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves4.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves4",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves5.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves5.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves5",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves6.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves6.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves6",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves7.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves7.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves7",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/green_archwood_leaves8.json
+++ b/assets/ars_nouveau/models/block/green_archwood_leaves8.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves8",  "textures": {    "0":"ars_nouveau:block/green_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves1.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves1.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves1",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves2.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves2.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves2",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves3.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves3.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves3",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves4.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves4.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves4",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves5.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves5.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves5",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves6.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves6.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves6",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves7.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves7.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves7",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/purple_archwood_leaves8.json
+++ b/assets/ars_nouveau/models/block/purple_archwood_leaves8.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves8",  "textures": {    "0":"ars_nouveau:block/purple_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves1.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves1.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves1",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves2.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves2.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves2",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves3.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves3.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves3",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves4.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves4.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves4",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves5.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves5.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves5",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves6.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves6.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves6",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves7.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves7.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves7",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/ars_nouveau/models/block/red_archwood_leaves8.json
+++ b/assets/ars_nouveau/models/block/red_archwood_leaves8.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves8",  "textures": {    "0":"ars_nouveau:block/red_archwood_leaves"  }}

--- a/assets/betterend/blockstates/lucernia_leaves.json
+++ b/assets/betterend/blockstates/lucernia_leaves.json
@@ -1,0 +1,10 @@
+{  "variants": {    "": [
+      { "model": "betterend:block/lucernia_leaves1" }, { "model": "betterend:block/lucernia_leaves1", "y": 90 }, { "model": "betterend:block/lucernia_leaves1", "y": 180 }, { "model": "betterend:block/lucernia_leaves1", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves2" }, { "model": "betterend:block/lucernia_leaves2", "y": 90 }, { "model": "betterend:block/lucernia_leaves2", "y": 180 }, { "model": "betterend:block/lucernia_leaves2", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves3" }, { "model": "betterend:block/lucernia_leaves3", "y": 90 }, { "model": "betterend:block/lucernia_leaves3", "y": 180 }, { "model": "betterend:block/lucernia_leaves3", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves4" }, { "model": "betterend:block/lucernia_leaves4", "y": 90 }, { "model": "betterend:block/lucernia_leaves4", "y": 180 }, { "model": "betterend:block/lucernia_leaves4", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves5" }, { "model": "betterend:block/lucernia_leaves5", "y": 90 }, { "model": "betterend:block/lucernia_leaves5", "y": 180 }, { "model": "betterend:block/lucernia_leaves5", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves6" }, { "model": "betterend:block/lucernia_leaves6", "y": 90 }, { "model": "betterend:block/lucernia_leaves6", "y": 180 }, { "model": "betterend:block/lucernia_leaves6", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves7" }, { "model": "betterend:block/lucernia_leaves7", "y": 90 }, { "model": "betterend:block/lucernia_leaves7", "y": 180 }, { "model": "betterend:block/lucernia_leaves7", "y": 270 },
+      { "model": "betterend:block/lucernia_leaves8" }, { "model": "betterend:block/lucernia_leaves8", "y": 90 }, { "model": "betterend:block/lucernia_leaves8", "y": 180 }, { "model": "betterend:block/lucernia_leaves8", "y": 270 }
+]}}

--- a/assets/betterend/blockstates/tenanea_leaves.json
+++ b/assets/betterend/blockstates/tenanea_leaves.json
@@ -1,0 +1,10 @@
+{  "variants": {    "": [
+      { "model": "betterend:block/tenanea_leaves1" }, { "model": "betterend:block/tenanea_leaves1", "y": 90 }, { "model": "betterend:block/tenanea_leaves1", "y": 180 }, { "model": "betterend:block/tenanea_leaves1", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves2" }, { "model": "betterend:block/tenanea_leaves2", "y": 90 }, { "model": "betterend:block/tenanea_leaves2", "y": 180 }, { "model": "betterend:block/tenanea_leaves2", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves3" }, { "model": "betterend:block/tenanea_leaves3", "y": 90 }, { "model": "betterend:block/tenanea_leaves3", "y": 180 }, { "model": "betterend:block/tenanea_leaves3", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves4" }, { "model": "betterend:block/tenanea_leaves4", "y": 90 }, { "model": "betterend:block/tenanea_leaves4", "y": 180 }, { "model": "betterend:block/tenanea_leaves4", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves5" }, { "model": "betterend:block/tenanea_leaves5", "y": 90 }, { "model": "betterend:block/tenanea_leaves5", "y": 180 }, { "model": "betterend:block/tenanea_leaves5", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves6" }, { "model": "betterend:block/tenanea_leaves6", "y": 90 }, { "model": "betterend:block/tenanea_leaves6", "y": 180 }, { "model": "betterend:block/tenanea_leaves6", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves7" }, { "model": "betterend:block/tenanea_leaves7", "y": 90 }, { "model": "betterend:block/tenanea_leaves7", "y": 180 }, { "model": "betterend:block/tenanea_leaves7", "y": 270 },
+      { "model": "betterend:block/tenanea_leaves8" }, { "model": "betterend:block/tenanea_leaves8", "y": 90 }, { "model": "betterend:block/tenanea_leaves8", "y": 180 }, { "model": "betterend:block/tenanea_leaves8", "y": 270 }
+]}}

--- a/assets/betterend/models/block/lucernia_leaves1.json
+++ b/assets/betterend/models/block/lucernia_leaves1.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves1",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves2.json
+++ b/assets/betterend/models/block/lucernia_leaves2.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves2",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves3.json
+++ b/assets/betterend/models/block/lucernia_leaves3.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves3",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves4.json
+++ b/assets/betterend/models/block/lucernia_leaves4.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves4",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves5.json
+++ b/assets/betterend/models/block/lucernia_leaves5.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves5",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves6.json
+++ b/assets/betterend/models/block/lucernia_leaves6.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves6",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves7.json
+++ b/assets/betterend/models/block/lucernia_leaves7.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves7",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/lucernia_leaves8.json
+++ b/assets/betterend/models/block/lucernia_leaves8.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves8",  "textures": {    "0":"betterend:block/lucernia_leaves_1"  }}

--- a/assets/betterend/models/block/tenanea_leaves1.json
+++ b/assets/betterend/models/block/tenanea_leaves1.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves1",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves2.json
+++ b/assets/betterend/models/block/tenanea_leaves2.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves2",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves3.json
+++ b/assets/betterend/models/block/tenanea_leaves3.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves3",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves4.json
+++ b/assets/betterend/models/block/tenanea_leaves4.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves4",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves5.json
+++ b/assets/betterend/models/block/tenanea_leaves5.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves5",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves6.json
+++ b/assets/betterend/models/block/tenanea_leaves6.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves6",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves7.json
+++ b/assets/betterend/models/block/tenanea_leaves7.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves7",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/betterend/models/block/tenanea_leaves8.json
+++ b/assets/betterend/models/block/tenanea_leaves8.json
@@ -1,0 +1,1 @@
+{"parent":"block/leaves8",  "textures": {    "0":"betterend:block/tenanea_leaves"  }}

--- a/assets/quark/models/block/ancient_leaves1.json
+++ b/assets/quark/models/block/ancient_leaves1.json
@@ -1,0 +1,6 @@
+{
+    "parent":"block/leaves1",
+    "textures": {
+        "0":"quark:block/ancient_leaves"
+    }
+}


### PR DESCRIPTION
This adds support for **Ars Nouveau** and updates some existing mods:
- Aether's namespace is now fixed and the leaves that weren't included before now are.
- BetterEnd support now includes the leaves that weren't added before.
- Quark now has an ancient_leaves1.json file which someone mistakenly left out before.

**A note about this PR:**
I wrote the Aether and Quark .jsons myself, they should match your existing formatting. All the other changes were made using the included datagen script from the repo, which is why some of the code looks unformatted. If that bothers you, you'll have to reformat the code yourself or use a code formatter such as Prettier.